### PR TITLE
Update makefile for PPPL and skip compiling mini_libstell

### DIFF
--- a/makefile
+++ b/makefile
@@ -105,7 +105,7 @@ export
 
 all: $(TARGET)
 
-include $(REGCOIL_PATH)/makefile.depend
+include makefile.depend
 
 %.o: %.f90 ${LIBSTELL_FOR_REGCOIL}
 	$(FC) $(EXTRA_COMPILE_FLAGS) -I $(LIBSTELL_DIR) -c $<

--- a/makefile
+++ b/makefile
@@ -55,8 +55,8 @@ else ifeq ($(HOSTNAME),pppl_gcc)
 	FC = mpifort
 	EXTRA_COMPILE_FLAGS = -O2 -ffree-line-length-none -fexternal-blas -fopenmp -I$(NETCDF_F)/include -I$(NETCDF_C)/include
 	EXTRA_LINK_FLAGS = -fopenmp -lopenblas -L$(NETCDF_C)/lib -lnetcdf -L$(NETCDF_F)/lib -lnetcdff
-    LIBSTELL_DIR=$(STELLOPT_PATH)/LIBSTELL/Release
-    LIBSTELL_FOR_REGCOIL=$(LIBSTELL_DIR)/libstell.a
+	LIBSTELL_DIR=$(STELLOPT_PATH)/LIBSTELL/Release
+	LIBSTELL_FOR_REGCOIL=$(LIBSTELL_DIR)/libstell.a
 	REGCOIL_COMMAND_TO_SUBMIT_JOB = srun -N 1 -n 1 -c 8 -q debug --mem 8G
 
 else ifeq ($(HOSTNAME),pppl_intel)
@@ -70,8 +70,8 @@ else ifeq ($(HOSTNAME),pppl_intel)
 		-I$(NETCDF_F)/include -I$(NETCDF_C)/include \
 		-mkl	
 	EXTRA_LINK_FLAGS = -qopenmp -mkl -L$(NETCDF_C)/lib -lnetcdf -L$(NETCDF_F)/lib -lnetcdff
-	    LIBSTELL_DIR=$(STELLOPT_PATH)/LIBSTELL/Release
-    LIBSTELL_FOR_REGCOIL=$(LIBSTELL_DIR)/libstell.a
+	LIBSTELL_DIR=$(STELLOPT_PATH)/LIBSTELL/Release
+	LIBSTELL_FOR_REGCOIL=$(LIBSTELL_DIR)/libstell.a
 	REGCOIL_COMMAND_TO_SUBMIT_JOB = srun -N 1 -n 1 -c 8 -q debug --mem 8G
 
 else ifeq ($(HOSTNAME),osx_brew)


### PR DESCRIPTION
Changes:

- The compiler options for PPPL and osx_brew have been updated
- The dependence of `mini-libstell.a` has been revised. Now if a complete `libstell.a` is specified, the `mini_libstell.a` will not be compiled, as it should be.